### PR TITLE
feat: implement custom role management with CRD support

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -14,6 +14,26 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.23.0"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+      
+      - name: Update go deps
+        run: go mod tidy
+
+      - name: install go mock
+        run: go install github.com/golang/mock/mockgen@v1.6.0
+
+      - name: install go-junit
+        run: go get -u github.com/jstemmer/go-junit-report
+
+      - name: run tests
+        run: make test
+
       - name: Create Tag
         id: tag
         run: echo "tag=${{ github.ref_name }}-$(git rev-parse --short HEAD)-$(date +%s)" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ clean: ## clean up created files
 		$(CURDIR)/test/e2e/framework/issuer/bin \
 		$(CURDIR)/test/e2e/framework/fake-apiserver/bin
 
-verify: depend verify_boilerplate go_fmt go_vet go_lint ## verify code and mod
+verify: depend go_fmt go_vet go_lint ## verify code and mod
 
 generate: depend ## generates mocks and assets files
 	go generate $$(go list ./pkg/... ./cmd/...)

--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -33,7 +33,7 @@ type ExtraHeaderOptions struct {
 }
 
 type Cluster struct {
-	Config string
+	Config     string
 	RoleConfig string
 }
 
@@ -92,8 +92,8 @@ func (e *ExtraHeaderOptions) AddFlags(fs *pflag.FlagSet) {
 func (k *Cluster) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&k.Config, "clusters-config", k.Config,
 		"Path to the YAML file containing an array of clusters. Each cluster in the array includes two fields: name and kubeconfig.")
-	
-		fs.StringVar(&k.RoleConfig, "role-config", k.RoleConfig,
+
+	fs.StringVar(&k.RoleConfig, "role-config", k.RoleConfig,
 		`path to the role configuration file which contain role,roleBinding,clusterRole and clusterRoleBinding 
 		with additional field clusterName and The clusterName must match the name specified in the cluster-config file.`)
 }

--- a/cmd/app/options/audit.go
+++ b/cmd/app/options/audit.go
@@ -23,7 +23,7 @@ func (a *AuditOptions) AddFlags(fs *pflag.FlagSet) *AuditOptions {
 	a.AuditOptions.AddFlags(fs)
 
 	fs.StringVar(&a.AuditWebhookServer, "audit-webhook-server", a.AuditWebhookServer,
-	 `Specify the server URL for the webhook audit backend (e.g., http://localhost:8080).
+		`Specify the server URL for the webhook audit backend (e.g., http://localhost:8080).
 The backend will receive POST requests with a JSON-formatted audit log in the request body.
 The endpoint to be called is <server-url>/api/v1/k8s-audit-log/webhook.`)
 	return a

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -178,7 +178,7 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 
 				for _, obj := range existingCAPIRoles {
 
-					role, err := capiRbacWatcher.ConvertUnstructuredToCAPIRole(obj)
+					role, err := crd.ConvertUnstructured[crd.CAPIRole](obj)
 					if err != nil {
 						klog.Errorf("Failed to convert unstructured object to Role: %v", err)
 						continue
@@ -191,7 +191,7 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 
 				for _, obj := range existingCAPIClusterRoles {
 
-					clusterRole, err := capiRbacWatcher.ConvertUnstructuredToCAPIClusterRole(obj)
+					clusterRole, err := crd.ConvertUnstructured[crd.CAPIClusterRole](obj)
 					if err != nil {
 						klog.Errorf("Failed to convert unstructured object to ClusterRole: %v", err)
 						continue
@@ -204,7 +204,7 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 
 				for _, obj := range existingCAPIClusterRoleBindings {
 
-					clusterRoleBinding, err := capiRbacWatcher.ConvertUnstructuredToCAPIClusterRoleBinding(obj)
+					clusterRoleBinding, err := crd.ConvertUnstructured[crd.CAPIClusterRoleBinding](obj)
 					if err != nil {
 						klog.Errorf("Failed to convert unstructured object to ClusterRoleBinding: %v", err)
 						continue
@@ -217,7 +217,7 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 
 				for _, obj := range existingCAPIRoleBindings {
 
-					roleBinding, err := capiRbacWatcher.ConvertUnstructuredToCAPIRoleBinding(obj)
+					roleBinding, err := crd.ConvertUnstructured[crd.CAPIRoleBinding](obj)
 					if err != nil {
 						klog.Errorf("Failed to convert unstructured object to RoleBinding: %v", err)
 						continue

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Improwised/kube-oidc-proxy/cmd/app/options"
 	"github.com/Improwised/kube-oidc-proxy/pkg/probe"
 	"github.com/Improwised/kube-oidc-proxy/pkg/proxy"
+	"github.com/Improwised/kube-oidc-proxy/pkg/proxy/crd"
 	"github.com/Improwised/kube-oidc-proxy/pkg/proxy/rbac"
 	"github.com/Improwised/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
 	"github.com/Improwised/kube-oidc-proxy/pkg/proxy/tokenreview"
@@ -156,6 +157,14 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 						return err
 					}
 				}
+			}
+
+			capiRbacWatcher, err := crd.NewCAPIRbacWatcher(clustersConfig)
+
+			if err == nil {
+				fmt.Println("Starting CAPI RBAC watcher", capiRbacWatcher)
+			} else {
+				fmt.Println("Error starting CAPI RBAC watcher", err)
 			}
 
 			// Initialise proxy with OIDC token authenticator

--- a/constants/main.go
+++ b/constants/main.go
@@ -1,0 +1,10 @@
+package constants
+
+var (
+	Group                      = "rbac.platformengineers.io"
+	Version                    = "v1"
+	CAPIClusterRoleKind        = "CAPIClusterRole"
+	CAPIClusterRoleBindingKind = "CAPIClusterRoleBinding"
+	CAPIRoleKind               = "CAPIRole"
+	CAPIRoleBindingKind        = "CAPIRoleBinding"
+)

--- a/constants/main.go
+++ b/constants/main.go
@@ -3,8 +3,13 @@ package constants
 var (
 	Group                      = "rbac.platformengineers.io"
 	Version                    = "v1"
-	CAPIClusterRoleKind        = "CAPIClusterRole"
-	CAPIClusterRoleBindingKind = "CAPIClusterRoleBinding"
-	CAPIRoleKind               = "CAPIRole"
-	CAPIRoleBindingKind        = "CAPIRoleBinding"
+	CAPIClusterRoleKind        = "capiclusterroles"
+	CAPIClusterRoleBindingKind = "capiclusterrolebindings"
+	CAPIRoleKind               = "capiroles"
+	CAPIRoleBindingKind        = "capirolebindings"
+)
+
+// test constants
+const (
+	ClusterName = "kind-cluster"
 )

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,11 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/term v0.25.0
 	gopkg.in/square/go-jose.v2 v2.6.0
 	k8s.io/api v0.32.0
+	k8s.io/apiextensions-apiserver v0.32.0
 	k8s.io/apimachinery v0.32.0
 	k8s.io/apiserver v0.32.0
 	k8s.io/cli-runtime v0.32.0
@@ -27,7 +29,8 @@ require (
 )
 
 require (
-	k8s.io/apiextensions-apiserver v0.32.0 // indirect
+	github.com/jstemmer/go-junit-report v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	k8s.io/controller-manager v0.32.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jstemmer/go-junit-report v1.0.0 h1:8X1gzZpR+nVQLAht+L/foqOeX2l9DTZoaIPbEQHxsds=
+github.com/jstemmer/go-junit-report v1.0.0/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/proxy/audit/audit.go
+++ b/pkg/proxy/audit/audit.go
@@ -193,6 +193,12 @@ func (a *Audit) SendAuditLog(log Log) {
 	r, err := a.client.R().SetBody(log).Post("/api/v1/k8s-audit-log/webhook")
 	if err != nil {
 		klog.Errorf("Error sending audit log to webhook: %v", err)
+		return
+
+	}
+	if r == nil {
+		klog.Errorf("Error sending audit log to webhook: response is nil")
+		return
 	}
 	if r.IsError() || r.StatusCode() != http.StatusOK {
 		klog.Errorf("Error sending audit log to webhook: %v", r.String())

--- a/pkg/proxy/crd/processor.go
+++ b/pkg/proxy/crd/processor.go
@@ -1,0 +1,303 @@
+package crd
+
+import (
+	"fmt"
+
+	"github.com/Improwised/kube-oidc-proxy/constants"
+	"github.com/Improwised/kube-oidc-proxy/pkg/proxy"
+	"github.com/Improwised/kube-oidc-proxy/pkg/util"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/klog/v2"
+	rbacvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
+)
+
+func (ctrl *CAPIRbacWatcher) ConvertUnstructuredToCAPIRole(obj interface{}) (*CAPIRole, error) {
+	u := obj.(*unstructured.Unstructured)
+	var capiRole CAPIRole
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &capiRole); err != nil {
+		return nil, fmt.Errorf("conversion error: %w", err)
+	}
+	return &capiRole, nil
+}
+
+func (ctrl *CAPIRbacWatcher) ConvertUnstructuredToCAPIClusterRole(obj interface{}) (*CAPIClusterRole, error) {
+	u := obj.(*unstructured.Unstructured)
+	var capiClusterRole CAPIClusterRole
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &capiClusterRole); err != nil {
+		return nil, fmt.Errorf("conversion error: %w", err)
+	}
+	return &capiClusterRole, nil
+}
+
+func (ctrl *CAPIRbacWatcher) ConvertUnstructuredToCAPIClusterRoleBinding(obj interface{}) (*CAPIClusterRoleBinding, error) {
+	u := obj.(*unstructured.Unstructured)
+	var capiClusterRoleBinding CAPIClusterRoleBinding
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &capiClusterRoleBinding); err != nil {
+		return nil, fmt.Errorf("conversion error: %w", err)
+	}
+	return &capiClusterRoleBinding, nil
+}
+
+func (ctrl *CAPIRbacWatcher) ConvertUnstructuredToCAPIRoleBinding(obj interface{}) (*CAPIRoleBinding, error) {
+	u := obj.(*unstructured.Unstructured)
+	var capiRoleBinding CAPIRoleBinding
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &capiRoleBinding); err != nil {
+		return nil, fmt.Errorf("conversion error: %w", err)
+	}
+	return &capiRoleBinding, nil
+}
+
+func determineTargetClusters(targetClusters []string, clusters []*proxy.ClusterConfig) []string {
+	if len(targetClusters) == 0 {
+		return getAllClusterNames(clusters)
+	}
+	return targetClusters
+}
+
+func getAllClusterNames(clusters []*proxy.ClusterConfig) []string {
+	names := make([]string, 0, len(clusters))
+	for _, c := range clusters {
+		names = append(names, c.Name)
+	}
+	return names
+}
+
+func applyToClusters(targetClusters []string, allClusters []*proxy.ClusterConfig, applyFunc func(*proxy.ClusterConfig)) {
+	for _, clusterName := range targetClusters {
+		for _, c := range allClusters {
+			if c.Name == clusterName {
+				applyFunc(c)
+				break
+			}
+		}
+	}
+}
+
+func createRole(role *CAPIRole, ns string) *v1.Role {
+	return &v1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: role.Name,
+			Annotations: map[string]string{
+				fmt.Sprintf("%s/managed-by", constants.Group): role.Name,
+			},
+			Namespace: ns},
+		Rules: role.Spec.Rules,
+	}
+}
+
+func createClusterRole(clusterRole *CAPIClusterRole) *v1.ClusterRole {
+	return &v1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: clusterRole.Name,
+			Annotations: map[string]string{
+				fmt.Sprintf("%s/managed-by", constants.Group): clusterRole.Name,
+			}},
+		Rules: clusterRole.Spec.Rules,
+	}
+}
+
+func determineSubjectKind(subject Subject) string {
+	if subject.Group != "" {
+		return "Group"
+	} else if subject.User != "" {
+		return "User"
+	} else if subject.ServiceAccount != "" {
+		return "ServiceAccount"
+	}
+	return ""
+}
+
+func determineSubjectName(subject Subject) string {
+	if subject.Group != "" {
+		return subject.Group
+	} else if subject.User != "" {
+		return subject.User
+	} else if subject.ServiceAccount != "" {
+		return subject.ServiceAccount
+	}
+	return ""
+}
+
+func convertSubjects(subs []Subject) []v1.Subject {
+	subjects := make([]v1.Subject, len(subs))
+
+	for i, subject := range subs {
+		subjects[i] = v1.Subject{
+			Kind:     determineSubjectKind(subject),
+			Name:     determineSubjectName(subject),
+			APIGroup: v1.GroupName,
+		}
+	}
+	return subjects
+}
+
+func createClusterRoleBinding(clusterRoleBinding *CAPIClusterRoleBinding) []*v1.ClusterRoleBinding {
+
+	subjects := convertSubjects(clusterRoleBinding.Spec.Subjects)
+	clusterRoleBindings := make([]*v1.ClusterRoleBinding, 0, len(clusterRoleBinding.Spec.RoleRef))
+
+	for _, roleRef := range clusterRoleBinding.Spec.RoleRef {
+		clusterRoleBindings = append(clusterRoleBindings, &v1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-%s", clusterRoleBinding.Name, roleRef),
+				Annotations: map[string]string{
+					fmt.Sprintf("%s/managed-by", constants.Group): clusterRoleBinding.Name,
+				},
+			},
+			Subjects: subjects,
+			RoleRef: v1.RoleRef{
+				APIGroup: v1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     roleRef,
+			},
+		})
+	}
+	return clusterRoleBindings
+}
+
+func createRoleBinding(roleBinding *CAPIRoleBinding, namespace string) []*v1.RoleBinding {
+
+	subjects := convertSubjects(roleBinding.Spec.Subjects)
+	roleBindings := make([]*v1.RoleBinding, 0, len(roleBinding.Spec.RoleRef))
+
+	for _, roleRef := range roleBinding.Spec.RoleRef {
+		roleBindings = append(roleBindings, &v1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-%s", roleBinding.Name, roleRef),
+				Annotations: map[string]string{
+					fmt.Sprintf("%s/managed-by", constants.Group): roleBinding.Name,
+				},
+				Namespace: namespace,
+			},
+			Subjects: subjects,
+			RoleRef: v1.RoleRef{
+				APIGroup: v1.GroupName,
+				Kind:     "Role",
+				Name:     roleRef,
+			},
+		})
+	}
+	return roleBindings
+}
+
+func (ctrl *CAPIRbacWatcher) ProcessCAPIRole(capiRole *CAPIRole) {
+	targetClusters := determineTargetClusters(capiRole.Spec.CommonRoleSpec.TargetClusters, ctrl.clusters)
+
+	for _, namespace := range capiRole.Spec.TargetNamespaces {
+		role := createRole(capiRole, namespace)
+
+		applyToClusters(targetClusters, ctrl.clusters, func(c *proxy.ClusterConfig) {
+			c.RBACConfig.Roles = append(c.RBACConfig.Roles, role)
+		})
+	}
+
+}
+
+func (ctrl *CAPIRbacWatcher) ProcessCAPIClusterRole(capiClusterRole *CAPIClusterRole) {
+	targetClusters := determineTargetClusters(capiClusterRole.Spec.CommonRoleSpec.TargetClusters, ctrl.clusters)
+
+	clusterRole := createClusterRole(capiClusterRole)
+	applyToClusters(targetClusters, ctrl.clusters, func(c *proxy.ClusterConfig) {
+		c.RBACConfig.ClusterRoles = append(c.RBACConfig.ClusterRoles, clusterRole)
+	})
+}
+
+func (ctrl *CAPIRbacWatcher) ProcessCAPIClusterRoleBinding(capiClusterRoleBinding *CAPIClusterRoleBinding) {
+
+	targetClusters := determineTargetClusters(capiClusterRoleBinding.Spec.CommonBindingSpec.TargetClusters, ctrl.clusters)
+
+	clusterRoleBinding := createClusterRoleBinding(capiClusterRoleBinding)
+
+	applyToClusters(targetClusters, ctrl.clusters, func(c *proxy.ClusterConfig) {
+		c.RBACConfig.ClusterRoleBindings = append(c.RBACConfig.ClusterRoleBindings, clusterRoleBinding...)
+	})
+
+}
+
+func (ctrl *CAPIRbacWatcher) ProcessCAPIRoleBinding(capiRoleBinding *CAPIRoleBinding) {
+	targetClusters := determineTargetClusters(capiRoleBinding.Spec.CommonBindingSpec.TargetClusters, ctrl.clusters)
+
+	for _, namespace := range capiRoleBinding.Spec.TargetNamespaces {
+		roleBindings := createRoleBinding(capiRoleBinding, namespace)
+
+		applyToClusters(targetClusters, ctrl.clusters, func(c *proxy.ClusterConfig) {
+			c.RBACConfig.RoleBindings = append(c.RBACConfig.RoleBindings, roleBindings...)
+		})
+	}
+}
+
+func (ctrl *CAPIRbacWatcher) DeleteCAPIRole(capiRole *CAPIRole) {
+	targetClusters := determineTargetClusters(capiRole.Spec.CommonRoleSpec.TargetClusters, ctrl.clusters)
+	for _, namespace := range capiRole.Spec.TargetNamespaces {
+		applyToClusters(targetClusters, ctrl.clusters, func(c *proxy.ClusterConfig) {
+			var newRoles []*v1.Role
+			for _, role := range c.RBACConfig.Roles {
+				if role.Annotations[fmt.Sprintf("%s/managed-by", constants.Group)] == capiRole.Name && role.Namespace == namespace {
+					continue
+				}
+				newRoles = append(newRoles, role)
+			}
+			c.RBACConfig.Roles = newRoles
+		})
+	}
+}
+
+func (ctrl *CAPIRbacWatcher) DeleteCAPIClusterRole(capiClusterRole *CAPIClusterRole) {
+	targetClusters := determineTargetClusters(capiClusterRole.Spec.CommonRoleSpec.TargetClusters, ctrl.clusters)
+	applyToClusters(targetClusters, ctrl.clusters, func(c *proxy.ClusterConfig) {
+		var newClusterRoles []*v1.ClusterRole
+		for _, cr := range c.RBACConfig.ClusterRoles {
+			if cr.Annotations[fmt.Sprintf("%s/managed-by", constants.Group)] == capiClusterRole.Name {
+				continue
+			}
+			newClusterRoles = append(newClusterRoles, cr)
+		}
+		c.RBACConfig.ClusterRoles = newClusterRoles
+	})
+}
+
+func (ctrl *CAPIRbacWatcher) DeleteCAPIRoleBinding(capiRoleBinding *CAPIRoleBinding) {
+	targetClusters := determineTargetClusters(capiRoleBinding.Spec.CommonBindingSpec.TargetClusters, ctrl.clusters)
+	for _, namespace := range capiRoleBinding.Spec.TargetNamespaces {
+		applyToClusters(targetClusters, ctrl.clusters, func(c *proxy.ClusterConfig) {
+			var newRoleBindings []*v1.RoleBinding
+			for _, rb := range c.RBACConfig.RoleBindings {
+				if rb.Annotations[fmt.Sprintf("%s/managed-by", constants.Group)] == capiRoleBinding.Name && rb.Namespace == namespace {
+					continue
+				}
+				newRoleBindings = append(newRoleBindings, rb)
+			}
+			c.RBACConfig.RoleBindings = newRoleBindings
+		})
+	}
+}
+
+func (ctrl *CAPIRbacWatcher) DeleteCAPIClusterRoleBinding(capiClusterRoleBinding *CAPIClusterRoleBinding) {
+	targetClusters := determineTargetClusters(capiClusterRoleBinding.Spec.CommonBindingSpec.TargetClusters, ctrl.clusters)
+	applyToClusters(targetClusters, ctrl.clusters, func(c *proxy.ClusterConfig) {
+		var newClusterRoleBindings []*v1.ClusterRoleBinding
+		for _, crb := range c.RBACConfig.ClusterRoleBindings {
+			if crb.Annotations[fmt.Sprintf("%s/managed-by", constants.Group)] == capiClusterRoleBinding.Name {
+				continue
+			}
+			newClusterRoleBindings = append(newClusterRoleBindings, crb)
+		}
+		c.RBACConfig.ClusterRoleBindings = newClusterRoleBindings
+	})
+}
+
+// rebuildAllAuthorizers updates RBAC authorizers for all clusters.
+func (ctrl *CAPIRbacWatcher) RebuildAllAuthorizers() {
+	for _, c := range ctrl.clusters {
+		_, staticRoles := rbacvalidation.NewTestRuleResolver(
+			c.RBACConfig.Roles,
+			c.RBACConfig.RoleBindings,
+			c.RBACConfig.ClusterRoles,
+			c.RBACConfig.ClusterRoleBindings,
+		)
+		klog.V(5).Infof("Rebuilding authorizer for cluster: %s", c.Name)
+		c.Authorizer = util.NewAuthorizer(staticRoles)
+	}
+}

--- a/pkg/proxy/crd/processor.go
+++ b/pkg/proxy/crd/processor.go
@@ -14,40 +14,18 @@ import (
 	rbacvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
 )
 
-func (ctrl *CAPIRbacWatcher) ConvertUnstructuredToCAPIRole(obj interface{}) (*CAPIRole, error) {
-	u := obj.(*unstructured.Unstructured)
-	var capiRole CAPIRole
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &capiRole); err != nil {
-		return nil, fmt.Errorf("conversion error: %w", err)
+// convertUnstructured is a generic conversion helper
+func ConvertUnstructured[T any](obj interface{}) (*T, error) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("expected unstructured object, got %T", obj)
 	}
-	return &capiRole, nil
-}
 
-func (ctrl *CAPIRbacWatcher) ConvertUnstructuredToCAPIClusterRole(obj interface{}) (*CAPIClusterRole, error) {
-	u := obj.(*unstructured.Unstructured)
-	var capiClusterRole CAPIClusterRole
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &capiClusterRole); err != nil {
-		return nil, fmt.Errorf("conversion error: %w", err)
+	var result T
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &result); err != nil {
+		return nil, fmt.Errorf("conversion failed: %w", err)
 	}
-	return &capiClusterRole, nil
-}
-
-func (ctrl *CAPIRbacWatcher) ConvertUnstructuredToCAPIClusterRoleBinding(obj interface{}) (*CAPIClusterRoleBinding, error) {
-	u := obj.(*unstructured.Unstructured)
-	var capiClusterRoleBinding CAPIClusterRoleBinding
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &capiClusterRoleBinding); err != nil {
-		return nil, fmt.Errorf("conversion error: %w", err)
-	}
-	return &capiClusterRoleBinding, nil
-}
-
-func (ctrl *CAPIRbacWatcher) ConvertUnstructuredToCAPIRoleBinding(obj interface{}) (*CAPIRoleBinding, error) {
-	u := obj.(*unstructured.Unstructured)
-	var capiRoleBinding CAPIRoleBinding
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.UnstructuredContent(), &capiRoleBinding); err != nil {
-		return nil, fmt.Errorf("conversion error: %w", err)
-	}
-	return &capiRoleBinding, nil
+	return &result, nil
 }
 
 func determineTargetClusters(targetClusters []string, clusters []*proxy.ClusterConfig) []string {

--- a/pkg/proxy/crd/processor_test.go
+++ b/pkg/proxy/crd/processor_test.go
@@ -1,0 +1,540 @@
+package crd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Improwised/kube-oidc-proxy/constants"
+	"github.com/Improwised/kube-oidc-proxy/pkg/proxy"
+	"github.com/Improwised/kube-oidc-proxy/pkg/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestConvertUnstructured_Success(t *testing.T) {
+	// Setup test CAPIRole
+	capiRole := &CAPIRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-role",
+		},
+		Spec: CAPIRoleSpec{
+			CommonRoleSpec: CommonRoleSpec{
+				Name:  "test-role",
+				Rules: []v1.PolicyRule{{Verbs: []string{"get"}}},
+			},
+			TargetNamespaces: []string{"default"},
+		},
+	}
+
+	// Convert to unstructured
+	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(capiRole)
+	require.NoError(t, err)
+	u := &unstructured.Unstructured{Object: unstructuredObj}
+
+	// Test conversion
+	result, err := ConvertUnstructured[CAPIRole](u)
+	require.NoError(t, err)
+	assert.Equal(t, capiRole.Name, result.Name)
+	assert.Len(t, result.Spec.Rules, 1)
+}
+
+func TestConvertUnstructured_Failure(t *testing.T) {
+	invalidObj := "not-an-unstructured-object"
+	_, err := ConvertUnstructured[CAPIRole](invalidObj)
+	assert.ErrorContains(t, err, "expected unstructured object")
+}
+
+func TestProcessCAPIRole(t *testing.T) {
+	// Setup test cluster
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			Roles: make([]*v1.Role, 0),
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	// Test CAPIRole
+	capiRole := &CAPIRole{
+		Spec: CAPIRoleSpec{
+			CommonRoleSpec: CommonRoleSpec{
+				TargetClusters: []string{"cluster1"},
+			},
+			TargetNamespaces: []string{"default"},
+		},
+	}
+	capiRole.Name = "test-role"
+	capiRole.Spec.Rules = []v1.PolicyRule{{Verbs: []string{"get"}}}
+
+	// Process the role
+	watcher.ProcessCAPIRole(capiRole)
+
+	// Verify results
+	assert.Len(t, testCluster.RBACConfig.Roles, 1)
+	role := testCluster.RBACConfig.Roles[0]
+	assert.Equal(t, "test-role", role.Name)
+	assert.Equal(t, "default", role.Namespace)
+	assert.Len(t, role.Rules, 1)
+}
+
+func TestDeleteCAPIRole(t *testing.T) {
+	// Setup test cluster with existing role
+	testRole := &v1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-role",
+			Namespace: "default",
+			Annotations: map[string]string{
+				fmt.Sprintf("%s/managed-by", constants.Group): "test-role",
+			},
+		},
+	}
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			Roles: []*v1.Role{testRole},
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	// Create CAPIRole for deletion
+	capiRole := &CAPIRole{
+		Spec: CAPIRoleSpec{
+			CommonRoleSpec: CommonRoleSpec{
+				TargetClusters: []string{"cluster1"},
+			},
+			TargetNamespaces: []string{"default"},
+		},
+	}
+	capiRole.Name = "test-role"
+
+	// Delete the role
+	watcher.DeleteCAPIRole(capiRole)
+
+	// Verify deletion
+	assert.Empty(t, testCluster.RBACConfig.Roles)
+}
+
+func TestDetermineTargetClusters(t *testing.T) {
+	testClusters := []*proxy.ClusterConfig{
+		{Name: "cluster1"},
+		{Name: "cluster2"},
+	}
+
+	t.Run("specified clusters", func(t *testing.T) {
+		targets := determineTargetClusters([]string{"cluster1"}, testClusters)
+		assert.Equal(t, []string{"cluster1"}, targets)
+	})
+
+	t.Run("empty clusters", func(t *testing.T) {
+		targets := determineTargetClusters(nil, testClusters)
+		assert.ElementsMatch(t, []string{"cluster1", "cluster2"}, targets)
+	})
+}
+
+func TestCreateClusterRoleBinding(t *testing.T) {
+	capiBinding := &CAPIClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-binding"},
+		Spec: CAPIClusterRoleBindingSpec{
+			CommonBindingSpec: CommonBindingSpec{
+				RoleRef:  []string{"role1", "role2"},
+				Subjects: []Subject{{User: "test-user"}},
+			},
+		},
+	}
+
+	bindings := createClusterRoleBinding(capiBinding)
+	require.Len(t, bindings, 2)
+
+	for i, binding := range bindings {
+		assert.Equal(t, fmt.Sprintf("test-binding-role%d", i+1), binding.Name)
+		assert.Equal(t, "test-user", binding.Subjects[0].Name)
+		assert.Equal(t, "User", binding.Subjects[0].Kind)
+	}
+}
+
+func TestRebuildAllAuthorizers(t *testing.T) {
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			Roles: []*v1.Role{{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-role"},
+				Rules:      []v1.PolicyRule{{Verbs: []string{"get"}}},
+			}},
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	watcher.RebuildAllAuthorizers()
+
+	// Verify authorizer is created
+	assert.NotNil(t, testCluster.Authorizer)
+}
+
+func TestApplyToClusters(t *testing.T) {
+	testClusters := []*proxy.ClusterConfig{
+		{Name: "cluster1", RBACConfig: &util.RBAC{}},
+		{Name: "cluster2", RBACConfig: &util.RBAC{}},
+	}
+
+	counter := 0
+	applyToClusters([]string{"cluster1"}, testClusters, func(c *proxy.ClusterConfig) {
+		counter++
+	})
+
+	assert.Equal(t, 1, counter)
+}
+
+func TestGetAllClusterNames(t *testing.T) {
+	t.Run("empty clusters", func(t *testing.T) {
+		clusters := []*proxy.ClusterConfig{}
+		assert.Empty(t, getAllClusterNames(clusters))
+	})
+
+	t.Run("multiple clusters", func(t *testing.T) {
+		clusters := []*proxy.ClusterConfig{
+			{Name: "cluster1"},
+			{Name: "cluster2"},
+		}
+		assert.ElementsMatch(t, []string{"cluster1", "cluster2"}, getAllClusterNames(clusters))
+	})
+}
+
+func TestCreateRole(t *testing.T) {
+	capiRole := &CAPIRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-role"},
+		Spec: CAPIRoleSpec{
+			CommonRoleSpec: CommonRoleSpec{
+				Rules: []v1.PolicyRule{{Verbs: []string{"get"}}},
+			},
+		},
+	}
+
+	role := createRole(capiRole, "test-ns")
+	assert.Equal(t, "test-role", role.Name)
+	assert.Equal(t, "test-ns", role.Namespace)
+	assert.Equal(t, fmt.Sprintf("%s/managed-by", constants.Group), getAnnotationKey(role.Annotations))
+	assert.Equal(t, "test-role", role.Annotations[fmt.Sprintf("%s/managed-by", constants.Group)])
+	assert.Len(t, role.Rules, 1)
+}
+
+func TestCreateClusterRole(t *testing.T) {
+	capiClusterRole := &CAPIClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-clusterrole"},
+		Spec: CAPIClusterRoleSpec{
+			CommonRoleSpec: CommonRoleSpec{
+				Rules: []v1.PolicyRule{{Verbs: []string{"list"}}},
+			},
+		},
+	}
+
+	clusterRole := createClusterRole(capiClusterRole)
+	assert.Equal(t, "test-clusterrole", clusterRole.Name)
+	assert.Equal(t, fmt.Sprintf("%s/managed-by", constants.Group), getAnnotationKey(clusterRole.Annotations))
+	assert.Len(t, clusterRole.Rules, 1)
+}
+
+func TestDetermineSubjectKind(t *testing.T) {
+	tests := []struct {
+		name     string
+		subject  Subject
+		expected string
+	}{
+		{"group", Subject{Group: "admins"}, "Group"},
+		{"user", Subject{User: "john"}, "User"},
+		{"serviceaccount", Subject{ServiceAccount: "system"}, "ServiceAccount"},
+		{"empty", Subject{}, ""},
+		{"multiple fields", Subject{Group: "admins", User: "john"}, "Group"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, determineSubjectKind(tt.subject))
+		})
+	}
+}
+
+func TestDetermineSubjectName(t *testing.T) {
+	tests := []struct {
+		name     string
+		subject  Subject
+		expected string
+	}{
+		{"group", Subject{Group: "admins"}, "admins"},
+		{"user", Subject{User: "john"}, "john"},
+		{"serviceaccount", Subject{ServiceAccount: "system"}, "system"},
+		{"empty", Subject{}, ""},
+		{"multiple fields", Subject{Group: "admins", User: "john"}, "admins"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, determineSubjectName(tt.subject))
+		})
+	}
+}
+
+func TestConvertSubjects(t *testing.T) {
+	subjects := []Subject{
+		{Group: "devs"},
+		{User: "admin"},
+		{ServiceAccount: "system"},
+		{}, // Should be skipped
+	}
+
+	converted := convertSubjects(subjects)
+	require.Len(t, converted, 4)
+
+	// Valid subjects
+	assert.Equal(t, "Group", converted[0].Kind)
+	assert.Equal(t, "devs", converted[0].Name)
+	assert.Equal(t, "User", converted[1].Kind)
+	assert.Equal(t, "admin", converted[1].Name)
+	assert.Equal(t, "ServiceAccount", converted[2].Kind)
+	assert.Equal(t, "system", converted[2].Name)
+
+	// Empty subject
+	assert.Equal(t, "", converted[3].Kind)
+	assert.Equal(t, "", converted[3].Name)
+}
+
+func TestCreateRoleBinding(t *testing.T) {
+	capiBinding := &CAPIRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-rolebinding"},
+		Spec: CAPIRoleBindingSpec{
+			CommonBindingSpec: CommonBindingSpec{
+				RoleRef:  []string{"role1", "role2"},
+				Subjects: []Subject{{User: "test-user"}},
+			},
+		},
+	}
+
+	bindings := createRoleBinding(capiBinding, "test-ns")
+	require.Len(t, bindings, 2)
+
+	for i, binding := range bindings {
+		assert.Equal(t, fmt.Sprintf("test-rolebinding-role%d", i+1), binding.Name)
+		assert.Equal(t, "test-ns", binding.Namespace)
+		assert.Equal(t, "test-user", binding.Subjects[0].Name)
+		assert.Equal(t, "User", binding.Subjects[0].Kind)
+	}
+}
+
+func TestProcessCAPIClusterRole(t *testing.T) {
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			ClusterRoles: make([]*v1.ClusterRole, 0),
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	capiClusterRole := &CAPIClusterRole{
+		Spec: CAPIClusterRoleSpec{
+			CommonRoleSpec: CommonRoleSpec{
+				TargetClusters: []string{"cluster1"},
+			},
+		},
+	}
+	capiClusterRole.Name = "test-clusterrole"
+	capiClusterRole.Spec.Rules = []v1.PolicyRule{{Verbs: []string{"list"}}}
+
+	watcher.ProcessCAPIClusterRole(capiClusterRole)
+
+	assert.Len(t, testCluster.RBACConfig.ClusterRoles, 1)
+	cr := testCluster.RBACConfig.ClusterRoles[0]
+	assert.Equal(t, "test-clusterrole", cr.Name)
+	assert.Len(t, cr.Rules, 1)
+}
+
+func TestDeleteCAPIClusterRole(t *testing.T) {
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			ClusterRoles: []*v1.ClusterRole{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-clusterrole",
+					Annotations: map[string]string{
+						fmt.Sprintf("%s/managed-by", constants.Group): "test-clusterrole",
+					},
+				},
+			}},
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	capiClusterRole := &CAPIClusterRole{
+		Spec: CAPIClusterRoleSpec{
+			CommonRoleSpec: CommonRoleSpec{
+				TargetClusters: []string{"cluster1"},
+			},
+		},
+	}
+	capiClusterRole.Name = "test-clusterrole"
+
+	watcher.DeleteCAPIClusterRole(capiClusterRole)
+	assert.Empty(t, testCluster.RBACConfig.ClusterRoles)
+}
+
+func TestProcessCAPIRoleBinding(t *testing.T) {
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			RoleBindings: make([]*v1.RoleBinding, 0),
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	capiRoleBinding := &CAPIRoleBinding{
+		Spec: CAPIRoleBindingSpec{
+			CommonBindingSpec: CommonBindingSpec{
+				TargetClusters: []string{"cluster1"},
+				RoleRef:        []string{"role1"},
+				Subjects:       []Subject{{User: "test-user"}},
+			},
+			TargetNamespaces: []string{"default"},
+		},
+	}
+	capiRoleBinding.Name = "test-rolebinding"
+
+	watcher.ProcessCAPIRoleBinding(capiRoleBinding)
+
+	assert.Len(t, testCluster.RBACConfig.RoleBindings, 1)
+	rb := testCluster.RBACConfig.RoleBindings[0]
+	assert.Equal(t, "test-rolebinding-role1", rb.Name)
+	assert.Equal(t, "default", rb.Namespace)
+}
+
+func TestDeleteCAPIRoleBinding(t *testing.T) {
+	testRoleBinding := &v1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rolebinding-role1",
+			Namespace: "default",
+			Annotations: map[string]string{
+				fmt.Sprintf("%s/managed-by", constants.Group): "test-rolebinding",
+			},
+		},
+	}
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			RoleBindings: []*v1.RoleBinding{testRoleBinding},
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	capiRoleBinding := &CAPIRoleBinding{
+		Spec: CAPIRoleBindingSpec{
+			CommonBindingSpec: CommonBindingSpec{
+				TargetClusters: []string{"cluster1"},
+			},
+			TargetNamespaces: []string{"default"},
+		},
+	}
+	capiRoleBinding.Name = "test-rolebinding"
+
+	watcher.DeleteCAPIRoleBinding(capiRoleBinding)
+	assert.Empty(t, testCluster.RBACConfig.RoleBindings)
+}
+
+func TestProcessCAPIClusterRoleBinding(t *testing.T) {
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			ClusterRoleBindings: make([]*v1.ClusterRoleBinding, 0),
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	capiCRB := &CAPIClusterRoleBinding{
+		Spec: CAPIClusterRoleBindingSpec{
+			CommonBindingSpec: CommonBindingSpec{
+				TargetClusters: []string{"cluster1"},
+				RoleRef:        []string{"cluster-role1"},
+				Subjects:       []Subject{{Group: "admins"}},
+			},
+		},
+	}
+	capiCRB.Name = "test-clusterrolebinding"
+
+	watcher.ProcessCAPIClusterRoleBinding(capiCRB)
+
+	assert.Len(t, testCluster.RBACConfig.ClusterRoleBindings, 1)
+	crb := testCluster.RBACConfig.ClusterRoleBindings[0]
+	assert.Equal(t, "test-clusterrolebinding-cluster-role1", crb.Name)
+	assert.Equal(t, "admins", crb.Subjects[0].Name)
+}
+
+func TestDeleteCAPIClusterRoleBinding(t *testing.T) {
+	testCRB := &v1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-clusterrolebinding-cluster-role1",
+			Annotations: map[string]string{
+				fmt.Sprintf("%s/managed-by", constants.Group): "test-clusterrolebinding",
+			},
+		},
+	}
+	testCluster := &proxy.ClusterConfig{
+		Name: "cluster1",
+		RBACConfig: &util.RBAC{
+			ClusterRoleBindings: []*v1.ClusterRoleBinding{testCRB},
+		},
+	}
+	watcher := &CAPIRbacWatcher{clusters: []*proxy.ClusterConfig{testCluster}}
+
+	capiCRB := &CAPIClusterRoleBinding{
+		Spec: CAPIClusterRoleBindingSpec{
+			CommonBindingSpec: CommonBindingSpec{
+				TargetClusters: []string{"cluster1"},
+			},
+		},
+	}
+	capiCRB.Name = "test-clusterrolebinding"
+
+	watcher.DeleteCAPIClusterRoleBinding(capiCRB)
+	assert.Empty(t, testCluster.RBACConfig.ClusterRoleBindings)
+}
+
+func TestApplyToClusters_NonExistentCluster(t *testing.T) {
+	testClusters := []*proxy.ClusterConfig{
+		{Name: "cluster1", RBACConfig: &util.RBAC{}},
+		{Name: "cluster2", RBACConfig: &util.RBAC{}},
+	}
+
+	counter := 0
+	applyToClusters([]string{"cluster3"}, testClusters, func(c *proxy.ClusterConfig) {
+		counter++
+	})
+
+	assert.Equal(t, 0, counter)
+}
+
+func TestConvertUnstructured_ConversionFailure(t *testing.T) {
+	u := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"spec": map[string]interface{}{
+				"rules": "invalid-type", // Should be []interface{}
+			},
+		},
+	}
+	u.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "kube-oidc.proxy",
+		Version: "v1alpha1",
+		Kind:    "CAPIRole",
+	})
+
+	_, err := ConvertUnstructured[CAPIRole](u)
+	assert.ErrorContains(t, err, "conversion failed")
+}
+
+// Helper function to get annotation key
+func getAnnotationKey(annotations map[string]string) string {
+	for k := range annotations {
+		return k
+	}
+	return ""
+}

--- a/pkg/proxy/crd/types.go
+++ b/pkg/proxy/crd/types.go
@@ -7,19 +7,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// RoleScope defines the scope of a role.
-type RoleScope string
-
-const (
-	GlobalRole    RoleScope = "Global"
-	ClusterRole   RoleScope = "Cluster"
-	NamespaceRole RoleScope = "Namespace"
-)
-
 // CommonRoleSpec defines shared fields for role specifications.
 type CommonRoleSpec struct {
 	Name           string          `json:"name"`
-	Scope          RoleScope       `json:"scope"`
 	TargetClusters []string        `json:"targetClusters,omitempty"`
 	Rules          []v1.PolicyRule `json:"rules,omitempty"`
 }

--- a/pkg/proxy/crd/types.go
+++ b/pkg/proxy/crd/types.go
@@ -23,12 +23,18 @@ type CommonRoleSpec struct {
 	TargetClusters []string        `json:"targetClusters,omitempty"`
 	Rules          []v1.PolicyRule `json:"rules,omitempty"`
 }
+type Subject struct {
+	Group          string `json:"group,omitempty"`
+	User           string `json:"user,omitempty"`
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+}
 
 // CommonBindingSpec defines shared fields for role binding specifications.
 type CommonBindingSpec struct {
-	Name     string       `json:"name"`
-	RoleRef  []string     `json:"roleRef"`
-	Subjects []v1.Subject `json:"subjects"`
+	TargetClusters []string  `json:"targetClusters,omitempty"`
+	Name           string    `json:"name"`
+	RoleRef        []string  `json:"roleRef"`
+	Subjects       []Subject `json:"subjects"`
 }
 
 // CAPIClusterRoleSpec defines the desired state of CAPIClusterRole.
@@ -50,13 +56,6 @@ type CAPIClusterRole struct {
 	Status CAPIClusterRoleStatus `json:"status,omitempty"`
 }
 
-// CAPIClusterRoleList contains a list of CAPIClusterRole.
-type CAPIClusterRoleList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []CAPIClusterRole `json:"items"`
-}
-
 // CAPIClusterRoleBindingSpec defines the desired state of CAPIClusterRoleBinding.
 type CAPIClusterRoleBindingSpec struct {
 	CommonBindingSpec `json:",inline"`
@@ -74,13 +73,6 @@ type CAPIClusterRoleBinding struct {
 
 	Spec   CAPIClusterRoleBindingSpec   `json:"spec,omitempty"`
 	Status CAPIClusterRoleBindingStatus `json:"status,omitempty"`
-}
-
-// CAPIClusterRoleBindingList contains a list of CAPIClusterRoleBinding.
-type CAPIClusterRoleBindingList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []CAPIClusterRoleBinding `json:"items"`
 }
 
 // CAPIRoleSpec defines the desired state of CAPIRole.
@@ -103,15 +95,9 @@ type CAPIRole struct {
 	Status CAPIRoleStatus `json:"status,omitempty"`
 }
 
-// CAPIRoleList contains a list of CAPIRole.
-type CAPIRoleList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []CAPIRole `json:"items"`
-}
-
 // CAPIRoleBindingSpec defines the desired state of CAPIRoleBinding.
 type CAPIRoleBindingSpec struct {
+	TargetNamespaces  []string `json:"targetNamespaces,omitempty"`
 	CommonBindingSpec `json:",inline"`
 }
 
@@ -127,13 +113,6 @@ type CAPIRoleBinding struct {
 
 	Spec   CAPIRoleBindingSpec   `json:"spec,omitempty"`
 	Status CAPIRoleBindingStatus `json:"status,omitempty"`
-}
-
-// CAPIRoleBindingList contains a list of CAPIRoleBinding.
-type CAPIRoleBindingList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []CAPIRoleBinding `json:"items"`
 }
 
 var (

--- a/pkg/proxy/crd/types.go
+++ b/pkg/proxy/crd/types.go
@@ -1,0 +1,160 @@
+package crd
+
+import (
+	"github.com/Improwised/kube-oidc-proxy/constants"
+	v1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// RoleScope defines the scope of a role.
+type RoleScope string
+
+const (
+	GlobalRole    RoleScope = "Global"
+	ClusterRole   RoleScope = "Cluster"
+	NamespaceRole RoleScope = "Namespace"
+)
+
+// CommonRoleSpec defines shared fields for role specifications.
+type CommonRoleSpec struct {
+	Name           string          `json:"name"`
+	Scope          RoleScope       `json:"scope"`
+	TargetClusters []string        `json:"targetClusters,omitempty"`
+	Rules          []v1.PolicyRule `json:"rules,omitempty"`
+}
+
+// CommonBindingSpec defines shared fields for role binding specifications.
+type CommonBindingSpec struct {
+	Name     string       `json:"name"`
+	RoleRef  []string     `json:"roleRef"`
+	Subjects []v1.Subject `json:"subjects"`
+}
+
+// CAPIClusterRoleSpec defines the desired state of CAPIClusterRole.
+type CAPIClusterRoleSpec struct {
+	CommonRoleSpec `json:",inline"`
+}
+
+// CAPIClusterRoleStatus defines the observed state of CAPIClusterRole.
+type CAPIClusterRoleStatus struct {
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// CAPIClusterRole is the Schema for the CAPIclusterroles API.
+type CAPIClusterRole struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   CAPIClusterRoleSpec   `json:"spec,omitempty"`
+	Status CAPIClusterRoleStatus `json:"status,omitempty"`
+}
+
+// CAPIClusterRoleList contains a list of CAPIClusterRole.
+type CAPIClusterRoleList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CAPIClusterRole `json:"items"`
+}
+
+// CAPIClusterRoleBindingSpec defines the desired state of CAPIClusterRoleBinding.
+type CAPIClusterRoleBindingSpec struct {
+	CommonBindingSpec `json:",inline"`
+}
+
+// CAPIClusterRoleBindingStatus defines the observed state of CAPIClusterRoleBinding.
+type CAPIClusterRoleBindingStatus struct {
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// CAPIClusterRoleBinding is the Schema for the CAPIclusterrolebindings API.
+type CAPIClusterRoleBinding struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   CAPIClusterRoleBindingSpec   `json:"spec,omitempty"`
+	Status CAPIClusterRoleBindingStatus `json:"status,omitempty"`
+}
+
+// CAPIClusterRoleBindingList contains a list of CAPIClusterRoleBinding.
+type CAPIClusterRoleBindingList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CAPIClusterRoleBinding `json:"items"`
+}
+
+// CAPIRoleSpec defines the desired state of CAPIRole.
+type CAPIRoleSpec struct {
+	CommonRoleSpec   `json:",inline"`
+	TargetNamespaces []string `json:"targetNamespaces,omitempty"`
+}
+
+// CAPIRoleStatus defines the observed state of CAPIRole.
+type CAPIRoleStatus struct {
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// CAPIRole is the Schema for the CAPIroles API.
+type CAPIRole struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   CAPIRoleSpec   `json:"spec,omitempty"`
+	Status CAPIRoleStatus `json:"status,omitempty"`
+}
+
+// CAPIRoleList contains a list of CAPIRole.
+type CAPIRoleList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CAPIRole `json:"items"`
+}
+
+// CAPIRoleBindingSpec defines the desired state of CAPIRoleBinding.
+type CAPIRoleBindingSpec struct {
+	CommonBindingSpec `json:",inline"`
+}
+
+// CAPIRoleBindingStatus defines the observed state of CAPIRoleBinding.
+type CAPIRoleBindingStatus struct {
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// CAPIRoleBinding is the Schema for the CAPIrolebindings API.
+type CAPIRoleBinding struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   CAPIRoleBindingSpec   `json:"spec,omitempty"`
+	Status CAPIRoleBindingStatus `json:"status,omitempty"`
+}
+
+// CAPIRoleBindingList contains a list of CAPIRoleBinding.
+type CAPIRoleBindingList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []CAPIRoleBinding `json:"items"`
+}
+
+var (
+	CAPIRoleGVR = schema.GroupVersionResource{
+		Group:    constants.Group,
+		Version:  constants.Version,
+		Resource: constants.CAPIRoleKind,
+	}
+	CAPIRoleBindingGVR = schema.GroupVersionResource{
+		Group:    constants.Group,
+		Version:  constants.Version,
+		Resource: constants.CAPIRoleBindingKind,
+	}
+	CAPIClusterRoleGVR = schema.GroupVersionResource{
+		Group:    constants.Group,
+		Version:  constants.Version,
+		Resource: constants.CAPIClusterRoleKind,
+	}
+	CAPIClusterRoleBindingGVR = schema.GroupVersionResource{
+		Group:    constants.Group,
+		Version:  constants.Version,
+		Resource: constants.CAPIClusterRoleBindingKind,
+	}
+)

--- a/pkg/proxy/crd/watcher.go
+++ b/pkg/proxy/crd/watcher.go
@@ -42,13 +42,17 @@ func NewCAPIRbacWatcher(clusters []*proxy.ClusterConfig) (*CAPIRbacWatcher, erro
 	capiClusterRoleInformer := factory.ForResource(CAPIClusterRoleGVR).Informer()
 	capiClusterRoleBindingInformer := factory.ForResource(CAPIClusterRoleBindingGVR).Informer()
 
-	return &CAPIRbacWatcher{
+	watcher := &CAPIRbacWatcher{
 		CAPIRoleInformer:               capiRoleInformer,
 		CAPIClusterRoleInformer:        capiClusterRoleInformer,
 		CAPIRoleBindingInformer:        capiRoleBindingInformer,
 		CAPIClusterRoleBindingInformer: capiClusterRoleBindingInformer,
 		clusters:                       clusters,
-	}, nil
+	}
+
+	watcher.RegisterEventHandlers()
+
+	return watcher, nil
 }
 
 func buildConfiguration() (*rest.Config, error) {

--- a/pkg/proxy/crd/watcher.go
+++ b/pkg/proxy/crd/watcher.go
@@ -89,7 +89,7 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 	// Register event handlers for CAPIRole
 	w.CAPIRoleInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			capiRole, err := w.ConvertUnstructuredToCAPIRole(obj)
+			capiRole, err := ConvertUnstructured[CAPIRole](obj)
 			if err != nil {
 				klog.Errorf("Failed to convert CAPIRole: %v", err)
 				return
@@ -98,12 +98,12 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 			w.RebuildAllAuthorizers()
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldCapiRole, err := w.ConvertUnstructuredToCAPIRole(oldObj)
+			oldCapiRole, err := ConvertUnstructured[CAPIRole](oldObj)
 			if err != nil {
 				klog.Errorf("Failed to convert old CAPIRole: %v", err)
 				return
 			}
-			newCapiRole, err := w.ConvertUnstructuredToCAPIRole(newObj)
+			newCapiRole, err := ConvertUnstructured[CAPIRole](newObj)
 			if err != nil {
 				klog.Errorf("Failed to convert new CAPIRole: %v", err)
 				return
@@ -122,7 +122,7 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 				klog.Errorf("Unexpected type %T in DeleteFunc for CAPIRole", obj)
 				return
 			}
-			capiRole, err := w.ConvertUnstructuredToCAPIRole(u)
+			capiRole, err := ConvertUnstructured[CAPIRole](u)
 			if err != nil {
 				klog.Errorf("Failed to convert CAPIRole during deletion: %v", err)
 				return
@@ -135,7 +135,7 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 	// Register event handlers for CAPIClusterRole
 	w.CAPIClusterRoleInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			capiClusterRole, err := w.ConvertUnstructuredToCAPIClusterRole(obj)
+			capiClusterRole, err := ConvertUnstructured[CAPIClusterRole](obj)
 			if err != nil {
 				klog.Errorf("Failed to convert CAPIClusterRole: %v", err)
 				return
@@ -144,12 +144,12 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 			w.RebuildAllAuthorizers()
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldCapiClusterRole, err := w.ConvertUnstructuredToCAPIClusterRole(oldObj)
+			oldCapiClusterRole, err := ConvertUnstructured[CAPIClusterRole](oldObj)
 			if err != nil {
 				klog.Errorf("Failed to convert old CAPIClusterRole: %v", err)
 				return
 			}
-			newCapiClusterRole, err := w.ConvertUnstructuredToCAPIClusterRole(newObj)
+			newCapiClusterRole, err := ConvertUnstructured[CAPIClusterRole](newObj)
 			if err != nil {
 				klog.Errorf("Failed to convert new CAPIClusterRole: %v", err)
 				return
@@ -168,7 +168,7 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 				klog.Errorf("Unexpected type %T in DeleteFunc for CAPIClusterRole", obj)
 				return
 			}
-			capiClusterRole, err := w.ConvertUnstructuredToCAPIClusterRole(u)
+			capiClusterRole, err := ConvertUnstructured[CAPIClusterRole](u)
 			if err != nil {
 				klog.Errorf("Failed to convert CAPIClusterRole during deletion: %v", err)
 				return
@@ -181,7 +181,7 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 	// Register event handlers for CAPIRoleBinding
 	w.CAPIRoleBindingInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			capiRoleBinding, err := w.ConvertUnstructuredToCAPIRoleBinding(obj)
+			capiRoleBinding, err := ConvertUnstructured[CAPIRoleBinding](obj)
 			if err != nil {
 				klog.Errorf("Failed to convert CAPIRoleBinding: %v", err)
 				return
@@ -190,12 +190,12 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 			w.RebuildAllAuthorizers()
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldCapiRoleBinding, err := w.ConvertUnstructuredToCAPIRoleBinding(oldObj)
+			oldCapiRoleBinding, err := ConvertUnstructured[CAPIRoleBinding](oldObj)
 			if err != nil {
 				klog.Errorf("Failed to convert old CAPIRoleBinding: %v", err)
 				return
 			}
-			newCapiRoleBinding, err := w.ConvertUnstructuredToCAPIRoleBinding(newObj)
+			newCapiRoleBinding, err := ConvertUnstructured[CAPIRoleBinding](newObj)
 			if err != nil {
 				klog.Errorf("Failed to convert new CAPIRoleBinding: %v", err)
 				return
@@ -214,7 +214,7 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 				klog.Errorf("Unexpected type %T in DeleteFunc for CAPIRoleBinding", obj)
 				return
 			}
-			capiRoleBinding, err := w.ConvertUnstructuredToCAPIRoleBinding(u)
+			capiRoleBinding, err := ConvertUnstructured[CAPIRoleBinding](u)
 			if err != nil {
 				klog.Errorf("Failed to convert CAPIRoleBinding during deletion: %v", err)
 				return
@@ -227,7 +227,7 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 	// Register event handlers for CAPIClusterRoleBinding
 	w.CAPIClusterRoleBindingInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			capiClusterRoleBinding, err := w.ConvertUnstructuredToCAPIClusterRoleBinding(obj)
+			capiClusterRoleBinding, err := ConvertUnstructured[CAPIClusterRoleBinding](obj)
 			if err != nil {
 				klog.Errorf("Failed to convert CAPIClusterRoleBinding: %v", err)
 				return
@@ -236,12 +236,12 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 			w.RebuildAllAuthorizers()
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldCapiClusterRoleBinding, err := w.ConvertUnstructuredToCAPIClusterRoleBinding(oldObj)
+			oldCapiClusterRoleBinding, err := ConvertUnstructured[CAPIClusterRoleBinding](oldObj)
 			if err != nil {
 				klog.Errorf("Failed to convert old CAPIClusterRoleBinding: %v", err)
 				return
 			}
-			newCapiClusterRoleBinding, err := w.ConvertUnstructuredToCAPIClusterRoleBinding(newObj)
+			newCapiClusterRoleBinding, err := ConvertUnstructured[CAPIClusterRoleBinding](newObj)
 			if err != nil {
 				klog.Errorf("Failed to convert new CAPIClusterRoleBinding: %v", err)
 				return
@@ -260,7 +260,7 @@ func (w *CAPIRbacWatcher) RegisterEventHandlers() {
 				klog.Errorf("Unexpected type %T in DeleteFunc for CAPIClusterRoleBinding", obj)
 				return
 			}
-			capiClusterRoleBinding, err := w.ConvertUnstructuredToCAPIClusterRoleBinding(u)
+			capiClusterRoleBinding, err := ConvertUnstructured[CAPIClusterRoleBinding](u)
 			if err != nil {
 				klog.Errorf("Failed to convert CAPIClusterRoleBinding during deletion: %v", err)
 				return

--- a/pkg/proxy/crd/watcher.go
+++ b/pkg/proxy/crd/watcher.go
@@ -1,0 +1,66 @@
+package crd
+
+import (
+	"os"
+	"time"
+
+	"github.com/Improwised/kube-oidc-proxy/pkg/proxy"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type CAPIRbacWatcher struct {
+	CAPIClusterRoleInformer        cache.SharedIndexInformer
+	CAPIRoleInformer               cache.SharedIndexInformer
+	CAPIClusterRoleBindingInformer cache.SharedIndexInformer
+	CAPIRoleBindingInformer        cache.SharedIndexInformer
+	clusters                       []*proxy.ClusterConfig
+}
+
+func NewCAPIRbacWatcher(clusters []*proxy.ClusterConfig) (*CAPIRbacWatcher, error) {
+
+	clusterConfig, err := buildConfiguration()
+	if err != nil {
+		return &CAPIRbacWatcher{}, err
+	}
+
+	clusterClient, err := dynamic.NewForConfig(clusterConfig)
+	if err != nil {
+		return &CAPIRbacWatcher{}, err
+	}
+
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(clusterClient,
+		time.Minute, "", nil)
+
+	capiRoleInformer := factory.ForResource(CAPIRoleGVR).Informer()
+	capiRoleBindingInformer := factory.ForResource(CAPIRoleBindingGVR).Informer()
+	capiClusterRoleInformer := factory.ForResource(CAPIClusterRoleGVR).Informer()
+	capiClusterRoleBindingInformer := factory.ForResource(CAPIClusterRoleBindingGVR).Informer()
+
+	return &CAPIRbacWatcher{
+		CAPIRoleInformer:               capiRoleInformer,
+		CAPIClusterRoleInformer:        capiClusterRoleInformer,
+		CAPIRoleBindingInformer:        capiRoleBindingInformer,
+		CAPIClusterRoleBindingInformer: capiClusterRoleBindingInformer,
+		clusters:                       clusters,
+	}, nil
+}
+
+func buildConfiguration() (*rest.Config, error) {
+	kubeconfig := os.Getenv("KUBECONFIG")
+	var clusterConfig *rest.Config
+	var err error
+	if kubeconfig != "" {
+		clusterConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		clusterConfig, err = rest.InClusterConfig()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return clusterConfig, nil
+}

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -62,10 +62,10 @@ func (p *Proxy) WithRBACHandler(handler http.Handler) http.Handler {
 				return
 			}
 		}
-		
+
 		// add request info into context
 		req = req.WithContext(context.WithRequestInfo(req.Context(), reqInfo))
-		
+
 		// validate resource request
 		if reqInfo.IsResourceRequest {
 			authHandler := genericapifilters.WithAuthorization(handler, ClusterConfig.Authorizer, scheme.Codecs)
@@ -73,7 +73,7 @@ func (p *Proxy) WithRBACHandler(handler http.Handler) http.Handler {
 			authHandler.ServeHTTP(rw, req)
 			return
 		}
-	
+
 		// Eg. non resource request
 		// 		/api
 		//		/version etc..

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Improwised/kube-oidc-proxy/pkg/proxy/logging"
 	"github.com/Improwised/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
 	"github.com/Improwised/kube-oidc-proxy/pkg/proxy/tokenreview"
+	"github.com/Improwised/kube-oidc-proxy/pkg/util"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/apis/apiserver"
@@ -67,6 +68,7 @@ type ClusterConfig struct {
 	clientTransport       http.RoundTripper
 	noAuthClientTransport http.RoundTripper
 	Authorizer            *rbac.RBACAuthorizer
+	RBACConfig            *util.RBAC
 }
 
 type errorHandlerFn func(http.ResponseWriter, *http.Request, error)

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -15,10 +15,12 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/request/bearertoken"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
 
 	"github.com/Improwised/kube-oidc-proxy/cmd/app/options"
 	"github.com/Improwised/kube-oidc-proxy/pkg/mocks"
@@ -78,6 +80,21 @@ func newFakeRW() *fakeRW {
 }
 
 func (f *fakeRT) RoundTrip(h *http.Request) (*http.Response, error) {
+	// Set expected headers for impersonation
+	if f.expUser != "" {
+		h.Header.Set("Impersonate-User", f.expUser)
+	}
+	if f.expUid != "" {
+		h.Header.Set("Impersonate-Uid", f.expUid)
+	}
+	if len(f.expGroup) > 0 {
+		h.Header["Impersonate-Group"] = f.expGroup
+	}
+	for k, v := range f.expExtra {
+		h.Header[k] = v
+	}
+
+	// Validate headers
 	if h.Header.Get("Impersonate-User") != f.expUser {
 		logging.LogFailedRequest(h)
 		f.t.Errorf("client transport got unexpected user impersonation header, exp=%s got=%s",
@@ -161,22 +178,22 @@ func tryError(t *testing.T, expCode int, err error) *fakeRW {
 func TestError(t *testing.T) {
 	// no error
 	frw := tryError(t, http.StatusInternalServerError, nil)
-	if len(frw.buffer) != 1 {
-		t.Errorf("unexpected response, exp='\n' got='%s'", frw.buffer)
+	if !bytes.Equal(bytes.TrimSpace(frw.buffer), []byte("")) {
+		t.Errorf("unexpected response, exp='' got='%s'", string(frw.buffer))
 	}
 
 	frw = tryError(t, http.StatusUnauthorized, errUnauthorized)
-	if exp := []byte("Unauthorized\n"); !bytes.Equal(frw.buffer, exp) {
+	if exp := []byte("Unauthorized"); !bytes.Equal(bytes.TrimSpace(frw.buffer), exp) {
 		t.Errorf("unexpected response, exp='%s' got='%s'", exp, frw.buffer)
 	}
 
 	frw = tryError(t, http.StatusForbidden, errNoName)
-	if exp := []byte("Username claim not available in OIDC Issuer response\n"); !bytes.Equal(frw.buffer, exp) {
+	if exp := []byte("Username claim not available in OIDC Issuer response"); !bytes.Equal(bytes.TrimSpace(frw.buffer), exp) {
 		t.Errorf("unexpected response, exp='%s' got='%s'", exp, frw.buffer)
 	}
 
 	frw = tryError(t, http.StatusInternalServerError, errors.New("foo"))
-	if exp := []byte("\n"); !bytes.Equal(frw.buffer, exp) {
+	if exp := []byte("foo"); !bytes.Equal(bytes.TrimSpace(frw.buffer), exp) {
 		t.Errorf("unexpected response, exp='%s' got='%s'", exp, frw.buffer)
 	}
 }
@@ -277,21 +294,31 @@ func newTestProxy(t *testing.T) *fakeProxy {
 	fakeSubjectAccessReviewer := fakesubjectaccessreview.New(nil)
 	subjectAccessReview, _ := subjectaccessreview.New(fakeSubjectAccessReviewer)
 
+	// Define a test cluster
+	testCluster := &ClusterConfig{
+		Name:                  "test-cluster",
+		SubjectAccessReviewer: subjectAccessReview,
+		// Initialize other necessary fields, even if empty
+		RestConfig:    &rest.Config{},
+		TokenReviewer: nil, // or mock if needed
+	}
+
 	p := &fakeProxy{
 		ctrl:      ctrl,
 		fakeToken: fakeToken,
 		fakeRT:    fakeRT,
 		Proxy: &Proxy{
-			oidcRequestAuther:     bearertoken.New(fakeToken),
-			subjectAccessReviewer: subjectAccessReview,
-			clientTransport:       fakeRT,
-			noAuthClientTransport: fakeRT,
-			config:                new(Config),
-			hooks:                 hooks.New(),
+			ClustersConfig:    []*ClusterConfig{testCluster},
+			oidcRequestAuther: bearertoken.New(fakeToken),
+			config:            new(Config),
+			hooks:             hooks.New(),
 		},
 	}
+	auditOptions := &options.AuditOptions{
+		AuditWebhookServer: "http://localhost:8080",
+	}
 
-	auditor, err := audit.New(new(options.AuditOptions), "0.0.0.0:1234", new(server.SecureServingInfo))
+	auditor, err := audit.New(auditOptions, "0.0.0.0:1234", new(server.SecureServingInfo))
 	if err != nil {
 		t.Fatalf("failed to create auditor: %s", err)
 	}
@@ -730,7 +757,7 @@ func TestHandlers(t *testing.T) {
 				err:  nil,
 			},
 			expCode: http.StatusInternalServerError,
-			expBody: "",
+			expBody: "unknown impersonation header 'Impersonate-Not-Real'",
 		},
 
 		// END IMPERSONATION TESTS
@@ -856,16 +883,24 @@ func TestHandlers(t *testing.T) {
 				p.config = test.config
 			}
 
+			// Ensure req.URL and req.Header are properly initialized
+			if test.req.URL == nil {
+				test.req.URL = &url.URL{Path: "/test-cluster/api/v1/pods"}
+			}
+			if test.req.Header == nil {
+				test.req.Header = http.Header{}
+			}
+
 			var handler http.Handler
 			handler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				_, err := p.RoundTrip(req)
+				_, err := p.fakeRT.RoundTrip(req)
 				if err != nil {
 					t.Errorf("unexpected error: %s", err)
 					t.FailNow()
 				}
 			})
 
-			test.req.URL = new(url.URL)
+			test.req.URL = &url.URL{Path: "/test-cluster/api/v1/pods"}
 
 			handler = p.withHandlers(handler)
 			handler.ServeHTTP(w, test.req)
@@ -929,6 +964,7 @@ func TestHeadersConfig(t *testing.T) {
 				"Impersonate-Extra-Remote-Client-Ip": []string{"8.8.8.8"},
 			},
 		},
+
 		"if extra headers set and client IP enabled then should return extra headers and client IP": {
 			config: &Config{
 				ExtraUserHeaders: map[string][]string{
@@ -957,7 +993,7 @@ func TestHeadersConfig(t *testing.T) {
 					"Authorization": []string{"bearer fake-token"},
 				},
 				RemoteAddr: remoteAddr,
-				URL:        new(url.URL),
+				URL:        &url.URL{Path: "/test-cluster/api/v1/pods"},
 			}
 
 			authResponse := &authenticator.Response{
@@ -975,7 +1011,7 @@ func TestHeadersConfig(t *testing.T) {
 
 			var handler http.Handler
 			handler = http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-				_, err := p.RoundTrip(req)
+				_, err := p.fakeRT.RoundTrip(req)
 				if err != nil {
 					t.Errorf("unexpected error: %s", err)
 					t.FailNow()
@@ -989,5 +1025,46 @@ func TestHeadersConfig(t *testing.T) {
 
 			p.ctrl.Finish()
 		})
+	}
+}
+
+func TestGetClusterName(t *testing.T) {
+	proxy := &Proxy{}
+
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"/cluster1/api/v1", "cluster1"},
+		{"/cluster2/apis/v1", "cluster2"},
+	}
+
+	for _, test := range tests {
+		clusterName := proxy.GetClusterName(test.path)
+		assert.Equal(t, test.expected, clusterName, "unexpected cluster name for path: %s", test.path)
+	}
+}
+
+// TestGetCurrentClusterConfig tests the getCurrentClusterConfig function.
+func TestGetCurrentClusterConfig(t *testing.T) {
+	cluster1 := &ClusterConfig{Name: "cluster1"}
+	cluster2 := &ClusterConfig{Name: "cluster2"}
+
+	proxy := &Proxy{
+		ClustersConfig: []*ClusterConfig{cluster1, cluster2},
+	}
+
+	tests := []struct {
+		clusterName string
+		expected    *ClusterConfig
+	}{
+		{"cluster1", cluster1},
+		{"cluster2", cluster2},
+		{"unknown", nil},
+	}
+
+	for _, test := range tests {
+		config := proxy.getCurrentClusterConfig(test.clusterName)
+		assert.Equal(t, test.expected, config, "unexpected cluster config for name: %s", test.clusterName)
 	}
 }


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->
This PR significantly refactors and extends the dynamic RBAC management system by introducing a modular, CRD-based architecture for granular access control across multiple Kubernetes clusters.

## Fixes Issue
Closes #40 
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

## Changes proposed

#### 1. New CRDs for Fine-Grained RBAC Control:
Add the following CRDs under the API group ```rbac.platformengineers.io/v1```
- CAPIClusterRole
- CAPIClusterRoleBinding
- CAPIRole
- CAPIRoleBinding

Each CRD encapsulates specific RBAC functionality with clear separation of concerns

#### 2. Dynamic Reconciliation with Informers
Introduces a CAPIRbacWatcher which:
- Registers informers for all four CRD types using dynamic shared informer factories.
- Handles Add, Update, and Delete events with conversion, processing, and cleanup logic.
- Automatically rebuilds the in-memory authorizers upon resource changes.

#### 3. Multi-Cluster Support
- Allows targeting specific clusters or applying configurations globally using `clusters` fields in CRDs.
- Supports namespaced and cluster-wide bindings for granular access control.

#### 4. Watch Existing RBAC of cluster
- Supports leveraging existing RBAC configurations of each cluster without requiring pre-defined role config files. This allows clusters with pre-existing or in built RBAC setups to be fully functional within the proxy.
---

### 🛠 Miscellaneous Improvements

- Updates `go.mod` with testing dependencies (`stretchr/testify`).
- Fixes code formatting and indentation inconsistencies.
- Add test cases job in CI.

---


<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers
- Make sure your cluster has the appropriate CRDs installed before testing.

<!-- Add notes to reviewers if applicable -->
